### PR TITLE
Update type of `source lines` to be `list<int>`

### DIFF
--- a/src/CodeUnit.php
+++ b/src/CodeUnit.php
@@ -26,7 +26,7 @@ abstract class CodeUnit
 
     /**
      * @var array
-     * @psalm-var array<int,int>
+     * @psalm-var list<int>
      */
     private $sourceLines;
 
@@ -192,7 +192,7 @@ abstract class CodeUnit
     }
 
     /**
-     * @psalm-param array<int,int> $sourceLines
+     * @psalm-param list<int> $sourceLines
      */
     private function __construct(string $name, string $sourceFileName, array $sourceLines)
     {
@@ -212,7 +212,7 @@ abstract class CodeUnit
     }
 
     /**
-     * @psalm-return array<int,int>
+     * @psalm-return list<int>
      */
     public function sourceLines(): array
     {

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -12,7 +12,7 @@ namespace SebastianBergmann\CodeUnit;
 final class Mapper
 {
     /**
-     * @psalm-return array<string,array<int,int>>
+     * @psalm-return array<string,list<int>>
      */
     public function codeUnitsToSourceLines(CodeUnitCollection $codeUnits): array
     {
@@ -29,7 +29,7 @@ final class Mapper
         }
 
         foreach (\array_keys($result) as $sourceFileName) {
-            $result[$sourceFileName] = \array_unique($result[$sourceFileName]);
+            $result[$sourceFileName] = \array_values(\array_unique($result[$sourceFileName]));
 
             \sort($result[$sourceFileName]);
         }


### PR DESCRIPTION
`range()` calls actually produce [`list<int>`](https://psalm.dev/docs/annotating_code/type_syntax/array_types/#lists) types. The latest [Psalm release](https://github.com/vimeo/psalm/releases/tag/3.9.4) supports that.