### PR TITLE
Implement FileUnit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Update dependencies with composer"
-        run: "COMPOSER_ROOT_VERSION=dev-master php7.4 ./tools/composer update --no-ansi --no-interaction --no-progress"
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
+        run: "php7.4 ./tools/composer update --no-ansi --no-interaction --no-progress"
 
       - name: "Run vimeo/psalm"
         run: "php7.4 ./tools/psalm --config=.psalm/config.xml --no-progress --shepherd --show-info=false --stats"
@@ -89,6 +91,8 @@ jobs:
           restore-keys: "php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 
       - name: "Install dependencies with composer"
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
         run: "./tools/composer update --no-ansi --no-interaction --no-progress"
 
       - name: "Run tests with phpunit/phpunit"
@@ -127,6 +131,8 @@ jobs:
           restore-keys: "php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 
       - name: "Install dependencies with composer"
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
         run: "./tools/composer update --no-ansi --no-interaction --no-progress"
 
       - name: "Run mutation tests with infection/infection"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
           extensions: intl
 
       - name: Run roave/backward-compatibility-check
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
         run: ./tools/roave-backward-compatibility-check --from=1.0.8
 
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Update dependencies with composer"
-        run: "php7.4 ./tools/composer update --no-ansi --no-interaction --no-progress"
+        run: "COMPOSER_ROOT_VERSION=dev-master php7.4 ./tools/composer update --no-ansi --no-interaction --no-progress"
 
       - name: "Run vimeo/psalm"
         run: "php7.4 ./tools/psalm --config=.psalm/config.xml --no-progress --shepherd --show-info=false --stats"

--- a/src/CodeUnit.php
+++ b/src/CodeUnit.php
@@ -90,7 +90,6 @@ abstract class CodeUnit
         );
     }
 
-
     /**
      * @psalm-param class-string $interfaceName
      *

--- a/src/CodeUnit.php
+++ b/src/CodeUnit.php
@@ -74,6 +74,24 @@ abstract class CodeUnit
     }
 
     /**
+     * @throws InvalidCodeUnitException
+     */
+    public static function forAbsoluteFile(string $absoluteFileName): FileUnit
+    {
+        self::ensureFileExistsAndIsReadable($absoluteFileName);
+
+        return new FileUnit(
+            'file:' . $absoluteFileName,
+            $absoluteFileName,
+            range(
+                1,
+                count(file($absoluteFileName))
+            )
+        );
+    }
+
+
+    /**
      * @psalm-param class-string $interfaceName
      *
      * @throws InvalidCodeUnitException
@@ -251,6 +269,26 @@ abstract class CodeUnit
     public function isFunction(): bool
     {
         return false;
+    }
+
+    public function isFile(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @throws InvalidCodeUnitException
+     */
+    private static function ensureFileExistsAndIsReadable(string $absoluteFileName): void
+    {
+        if (!(file_exists($absoluteFileName) && is_readable($absoluteFileName))) {
+            throw new InvalidCodeUnitException(
+                sprintf(
+                    'file "%s" does not exist or is not readable',
+                    $absoluteFileName
+                )
+            );
+        }
     }
 
     /**

--- a/src/FileUnit.php
+++ b/src/FileUnit.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/code-unit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeUnit;
+
+/**
+ * @psalm-immutable
+ */
+final class FileUnit extends CodeUnit
+{
+    /**
+     * @psalm-assert-if-true FileUnit $this
+     */
+    public function isFile(): bool
+    {
+        return true;
+    }
+}

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -63,7 +63,7 @@ final class Mapper
      */
     public function stringToCodeUnits(string $unit): CodeUnitCollection
     {
-        if (preg_match('~^file:(/.*)$~', $unit, $matches)) {
+        if (preg_match('~^file:(/.*)~', $unit, $matches)) {
             return CodeUnitCollection::fromArray([CodeUnit::forAbsoluteFile($matches[1])]);
         }
 

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -65,7 +65,9 @@ final class Mapper
     {
         if (preg_match('~^file:(/.*)$~', $unit, $matches)) {
             return CodeUnitCollection::fromArray([CodeUnit::forAbsoluteFile($matches[1])]);
-        } elseif (strpos($unit, '::') !== false) {
+        }
+
+        if (strpos($unit, '::') !== false) {
             [$firstPart, $secondPart] = explode('::', $unit);
 
             if ($this->isUserDefinedFunction($secondPart)) {

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -63,7 +63,9 @@ final class Mapper
      */
     public function stringToCodeUnits(string $unit): CodeUnitCollection
     {
-        if (strpos($unit, '::') !== false) {
+        if (preg_match('~^file:(/.*)$~', $unit, $matches)) {
+            return CodeUnitCollection::fromArray([CodeUnit::forAbsoluteFile($matches[1])]);
+        } elseif (strpos($unit, '::') !== false) {
             [$firstPart, $secondPart] = explode('::', $unit);
 
             if ($this->isUserDefinedFunction($secondPart)) {
@@ -83,8 +85,6 @@ final class Mapper
             if ($this->isUserDefinedTrait($firstPart)) {
                 return CodeUnitCollection::fromList(CodeUnit::forTraitMethod($firstPart, $secondPart));
             }
-        } elseif (preg_match('/^file:(.*)$/', $unit, $matches)) {
-            return CodeUnitCollection::fromArray([CodeUnit::forAbsoluteFile($matches[1])]);
         } else {
             if ($this->isUserDefinedClass($unit)) {
                 $units = [CodeUnit::forClass($unit)];

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -83,6 +83,8 @@ final class Mapper
             if ($this->isUserDefinedTrait($firstPart)) {
                 return CodeUnitCollection::fromList(CodeUnit::forTraitMethod($firstPart, $secondPart));
             }
+        } elseif (preg_match('/^file:(.*)$/', $unit, $matches)) {
+            return CodeUnitCollection::fromArray([CodeUnit::forAbsoluteFile($matches[1])]);
         } else {
             if ($this->isUserDefinedClass($unit)) {
                 $units = [CodeUnit::forClass($unit)];

--- a/tests/_fixture/function.php
+++ b/tests/_fixture/function.php
@@ -20,4 +20,9 @@ namespace
     {
         return 1;
     }
+
+    class file
+    {
+        public function test(): void {}
+    }
 }

--- a/tests/_fixture/function.php
+++ b/tests/_fixture/function.php
@@ -23,6 +23,8 @@ namespace
 
     class file
     {
-        public function test(): void {}
+        public function test(): void
+        {
+        }
     }
 }

--- a/tests/unit/ClassUnitTest.php
+++ b/tests/unit/ClassUnitTest.php
@@ -40,6 +40,7 @@ final class ClassUnitTest extends TestCase
         $this->assertFalse($unit->isTrait());
         $this->assertFalse($unit->isTraitMethod());
         $this->assertFalse($unit->isFunction());
+        $this->assertFalse($unit->isFile());
 
         $this->assertSame(FixtureClass::class, $unit->name());
         $this->assertSame(realpath(__DIR__ . '/../_fixture/FixtureClass.php'), $unit->sourceFileName());

--- a/tests/unit/FileUnitTest.php
+++ b/tests/unit/FileUnitTest.php
@@ -41,7 +41,7 @@ final class FileUnitTest extends TestCase
 
         $this->assertSame('file:' . $file, $unit->name());
         $this->assertSame(realpath($file), $unit->sourceFileName());
-        $this->assertSame(range(1, 53), $unit->sourceLines());
+        $this->assertSame(range(1, 65), $unit->sourceLines());
     }
 
     public function testCannotBeCreatedForNonExistentFile(): void
@@ -49,5 +49,17 @@ final class FileUnitTest extends TestCase
         $this->expectException(InvalidCodeUnitException::class);
 
         CodeUnit::forAbsoluteFile(__DIR__ . '/FileUnitTest2.php');
+    }
+
+    public function testCannotBeCreatedForUnreadableFile(): void
+    {
+        $tmpFile = tmpfile();
+        $fileName= stream_get_meta_data($tmpFile)['uri'];
+        $this->assertTrue(chmod($fileName, 0000));
+        $this->assertFalse(is_readable($fileName));
+
+        $this->expectException(InvalidCodeUnitException::class);
+
+        CodeUnit::forAbsoluteFile($fileName);
     }
 }

--- a/tests/unit/FileUnitTest.php
+++ b/tests/unit/FileUnitTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/code-unit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\CodeUnit;
+
+use PHPUnit\Framework\TestCase;
+use function range;
+use function realpath;
+
+/**
+ * @covers \SebastianBergmann\CodeUnit\ClassMethodUnit
+ * @covers \SebastianBergmann\CodeUnit\CodeUnit
+ *
+ * @uses \SebastianBergmann\CodeUnit\CodeUnitCollection
+ * @uses \SebastianBergmann\CodeUnit\CodeUnitCollectionIterator
+ * @uses \SebastianBergmann\CodeUnit\Mapper
+ *
+ * @testdox ClassMethodUnit
+ */
+final class FileUnitTest extends TestCase
+{
+    public function testCanBeCreatedFromAbsoluteFileName(): void
+    {
+        $file = realpath(__FILE__);
+        $unit = CodeUnit::forAbsoluteFile($file);
+
+        $this->assertFalse($unit->isClass());
+        $this->assertFalse($unit->isClassMethod());
+        $this->assertFalse($unit->isInterface());
+        $this->assertFalse($unit->isInterfaceMethod());
+        $this->assertFalse($unit->isTrait());
+        $this->assertFalse($unit->isTraitMethod());
+        $this->assertFalse($unit->isFunction());
+        $this->assertTrue($unit->isFile());
+
+        $this->assertSame('file:' .$file, $unit->name());
+        $this->assertSame(realpath($file), $unit->sourceFileName());
+        $this->assertSame(range(1, 53), $unit->sourceLines());
+    }
+
+    public function testCannotBeCreatedForNonExistentFile(): void
+    {
+        $this->expectException(InvalidCodeUnitException::class);
+
+        CodeUnit::forAbsoluteFile(__DIR__ . '/FileUnitTest2.php');
+    }
+}

--- a/tests/unit/FileUnitTest.php
+++ b/tests/unit/FileUnitTest.php
@@ -14,7 +14,7 @@ use function realpath;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \SebastianBergmann\CodeUnit\ClassMethodUnit
+ * @covers \SebastianBergmann\CodeUnit\FileUnit
  * @covers \SebastianBergmann\CodeUnit\CodeUnit
  *
  * @uses \SebastianBergmann\CodeUnit\CodeUnitCollection

--- a/tests/unit/FileUnitTest.php
+++ b/tests/unit/FileUnitTest.php
@@ -9,9 +9,9 @@
  */
 namespace SebastianBergmann\CodeUnit;
 
-use PHPUnit\Framework\TestCase;
 use function range;
 use function realpath;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \SebastianBergmann\CodeUnit\ClassMethodUnit
@@ -39,7 +39,7 @@ final class FileUnitTest extends TestCase
         $this->assertFalse($unit->isFunction());
         $this->assertTrue($unit->isFile());
 
-        $this->assertSame('file:' .$file, $unit->name());
+        $this->assertSame('file:' . $file, $unit->name());
         $this->assertSame(realpath($file), $unit->sourceFileName());
         $this->assertSame(range(1, 53), $unit->sourceLines());
     }

--- a/tests/unit/MapperTest.php
+++ b/tests/unit/MapperTest.php
@@ -123,7 +123,7 @@ final class MapperTest extends TestCase
     }
 
     /**
-     * @testdox Can map 'file::[[absolute-path]]' string to code unit objects
+     * @testdox Can map 'file:[[absolute-path]]' string to code unit objects
      */
     public function testCanMapStringWithFileNameToCodeUnitObjects(): void
     {
@@ -132,6 +132,18 @@ final class MapperTest extends TestCase
         $this->assertSame('file:' . realpath(__FILE__), $units->asArray()[0]->name());
     }
 
+    public function testCanMapClassThatLooksLikeFileAnnotation(): void
+    {
+        $units = (new Mapper)->stringToCodeUnits(\file::class . '::test');
+        $this->assertInstanceOf(ClassMethodUnit::class, $units->asArray()[0]);
+    }
+
+    public function testCannotMapBadFileAnnotation(): void
+    {
+        $this->expectException(InvalidCodeUnitException::class);
+
+        (new Mapper)->stringToCodeUnits('not a file:' . realpath(__FILE__));
+    }
     public function testCannotMapInvalidStringToCodeUnitObjects(): void
     {
         $this->expectException(InvalidCodeUnitException::class);

--- a/tests/unit/MapperTest.php
+++ b/tests/unit/MapperTest.php
@@ -11,6 +11,7 @@ namespace SebastianBergmann\CodeUnit;
 
 use function range;
 use function realpath;
+use file;
 use PHPUnit\Framework\TestCase;
 use SebastianBergmann\CodeUnit\Fixture\FixtureAnotherChildClass;
 use SebastianBergmann\CodeUnit\Fixture\FixtureAnotherParentClass;
@@ -134,7 +135,7 @@ final class MapperTest extends TestCase
 
     public function testCanMapClassThatLooksLikeFileAnnotation(): void
     {
-        $units = (new Mapper)->stringToCodeUnits(\file::class . '::test');
+        $units = (new Mapper)->stringToCodeUnits(file::class . '::test');
         $this->assertInstanceOf(ClassMethodUnit::class, $units->asArray()[0]);
     }
 
@@ -144,6 +145,7 @@ final class MapperTest extends TestCase
 
         (new Mapper)->stringToCodeUnits('not a file:' . realpath(__FILE__));
     }
+
     public function testCannotMapInvalidStringToCodeUnitObjects(): void
     {
         $this->expectException(InvalidCodeUnitException::class);

--- a/tests/unit/MapperTest.php
+++ b/tests/unit/MapperTest.php
@@ -122,6 +122,16 @@ final class MapperTest extends TestCase
         $this->assertSame(FixtureTrait::class . '::method', $units->asArray()[0]->name());
     }
 
+    /**
+     * @testdox Can map 'file::[[absolute-path]]' string to code unit objects
+     */
+    public function testCanMapStringWithFileNameToCodeUnitObjects(): void
+    {
+        $units = (new Mapper)->stringToCodeUnits('file:' . realpath(__FILE__));
+
+        $this->assertSame('file:' . realpath(__FILE__), $units->asArray()[0]->name());
+    }
+
     public function testCannotMapInvalidStringToCodeUnitObjects(): void
     {
         $this->expectException(InvalidCodeUnitException::class);


### PR DESCRIPTION
This PR adds support for code units that cover files.
It should not break any existing code since we use a pattern for the `@covers` annotation that does not collide with the existing patterns.


### Future work: relative paths
Future work would be to add support for relative paths, the most important open question for this is: _relative to what?_

Using relative paths would require some configuration, which we either have to inject or extract from global state. A simple but arguably not very pretty solution would be to use PHP's search path.
Another solution would be to add a static configurator function to mapper, that is easy to implement but could be considered fairly ugly.

```php
class Mapper {
    public static function setBasePathForRelativePaths($absoluteDirectoryPath): void {
        self::assertDirectoryExists($absoluteDirectoryPath);
        self::$basePath = $absoluteDirectoryPath;
    }
```

Another option would be to change `Test::getLinesToBeCovered()` to allow a `Mapper` instance to be passed in:

```php
    public static function getLinesToBeCovered(string $className, string $methodName, Mapper $mapper = null)
```

This would allow callers to optionally pass in their own `Mapper`, but requires a lot more changes everywhere in the chain..